### PR TITLE
[api] Add new API call to configure OSGI Configuration Nodes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - Add client generation for all languages supported by OpenAPI Generator
+- Add new API to configure any configuration node shinesolutions/ruby_aem#31
 
 ## [3.1.0] - 2019-06-04
 

--- a/conf/api.yml
+++ b/conf/api.yml
@@ -178,6 +178,20 @@ paths:
       responses:
         default:
           description: Default response
+  /apps/system/config/{configNodeName}:
+    post:
+      operationId: postConfigProperty
+      parameters:
+        - name: configNodeName
+          in: path
+          required: true
+          schema:
+            type: string
+      tags:
+        - sling
+      responses:
+        default:
+          description: Default response
   /apps/system/config/org.apache.felix.http:
     post:
       operationId: postConfigApacheFelixJettyBasedHttpService


### PR DESCRIPTION
This PR extends the API Call with an additional one to support the configuration of all available OSGI configurations at `/apps/system/config/{configNodeName}`

### Added
Add new API to configure any configuration node 
shinesolutions/ruby_aem#31