### PR TITLE
Changed usage of cgi.escape to erb::util.url_encode in crx_api.rb cli…

### DIFF
--- a/clients/ruby/generated/lib/swagger_aem/api/crx_api.rb
+++ b/clients/ruby/generated/lib/swagger_aem/api/crx_api.rb
@@ -10,7 +10,7 @@ OpenAPI Generator version: 4.3.1
 
 =end
 
-require 'cgi'
+require 'erb'
 
 module SwaggerAemClient
   class CrxApi
@@ -274,7 +274,7 @@ module SwaggerAemClient
         fail ArgumentError, "Missing the required parameter 'cmd' when calling CrxApi.post_package_service_json"
       end
       # resource path
-      local_var_path = '/crx/packmgr/service/.json/{path}'.sub('{' + 'path' + '}', CGI.escape(path.to_s))
+      local_var_path = '/crx/packmgr/service/.json/{path}'.sub('{' + 'path' + '}', ERB::Util.url_encode(path.to_s))
 
       # query parameters
       query_params = opts[:query_params] || {}


### PR DESCRIPTION
Changed usage of cgi.escape to erb::util.url_encode in crx_api.rb client to properly handle spaces in path