### PR TITLE
Add support for the aliasUpdate property (being used in replication flush agent)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
+### Added
+- Added the possibility to configure the aliasUpdate for a replication flush agent.
 
 ## 3.7.0 - 2022-09-07
 ### Added

--- a/conf/api.yml
+++ b/conf/api.yml
@@ -684,6 +684,11 @@ paths:
           required: false
           schema:
             type: string
+        - name: jcr:content/aliasUpdate
+          in: query
+          required: false
+          schema:
+            type: boolean
         - name: jcr:content/enabled
           in: query
           required: false


### PR DESCRIPTION
Required for: 
- https://github.com/shinesolutions/puppet-aem-resources/pull/116
- https://github.com/shinesolutions/ruby_aem/pull/47